### PR TITLE
Remove a dependency on a created user prompt and switch to TTS

### DIFF
--- a/terraform/modules/flows/in-queue-flow-orbit-park-hold/in-queue-orbit-call-park-hold.yaml
+++ b/terraform/modules/flows/in-queue-flow-orbit-park-hold/in-queue-orbit-call-park-hold.yaml
@@ -62,7 +62,7 @@ inqueueCall:
     - playAudio:
         name: Play Audio
         audio:
-          prompt: Prompt.PleaseHoldAsYourCallsRetrieved
+          tts: Please hold as your call is retrieved
     - playAudio:
         name: Play Audio
         audio:
@@ -70,4 +70,4 @@ inqueueCall:
     - playAudio:
         name: Play Audio
         audio:
-          prompt: Prompt.PleaseHoldAsYourCallsRetrieved
+          tts: Please hold as your call is retrieved


### PR DESCRIPTION
The in-queue-orbit-call-park-hold.yaml file contains a reference to the user prompt: Prompt.PleaseHoldAsYourCallsRetrieved. Removing this dependency and switching to TTS so this prompt would not need to be created.